### PR TITLE
Remove pdfplumber package duplication and adds the package pikepdf to requirements.txt to avoid pdf text extraction failure due to clash in unstructured package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ langchain_text_splitters
 unstructured
 unstructured[all-docs]
 fastembed
-pdfplumber
+pikepdf
 sentence-transformers
 elevenlabs


### PR DESCRIPTION
Avoid installing pikepdf in the requirements.txt file, as it can cause PDF text extraction failures. This issue occurs because pikepdf conflicts with the unstructured package when pikepdf is installed before unstructured. To prevent this, ensure that unstructured is installed first, then installing pikepdf.